### PR TITLE
Bug/audio video linking error on windows

### DIFF
--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -103,44 +103,38 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
     const char * sink_name)
 {
   GstPad *qpad;
-  GstElement *q, *conv, *resample = NULL, *sink;
+  GstElement *q, *conv, *resample, *sink;
   GstPadLinkReturn ret;
   
   g_print ("Trying to handle stream with %s ! %s", convert_name, sink_name);
 
-  q = gst_element_factory_make("queue", NULL);
-  g_assert(q);
-  conv = gst_element_factory_make(convert_name, NULL);
-  g_assert(conv);
-  sink = gst_element_factory_make(sink_name, NULL);
-  g_assert(sink);
+  q = gst_element_factory_make ("queue", NULL);
+  g_assert_nonnull (q);
+  conv = gst_element_factory_make (convert_name, NULL);
+  g_assert_nonnull (conv);
+  sink = gst_element_factory_make (sink_name, NULL);
+  g_assert_nonnull (sink);
 
   if (convert_name == "audioconvert") {
-    resample = gst_element_factory_make("audioresample", NULL);
-    g_assert(resample);
-    gst_bin_add_many(GST_BIN(pipe), q, conv, resample, sink, NULL);
-    gst_element_sync_state_with_parent(q);
-	gst_element_sync_state_with_parent(conv);
-	gst_element_sync_state_with_parent(resample);
-	gst_element_sync_state_with_parent(sink);
-  }
-  else {
-    gst_bin_add_many(GST_BIN(pipe), q, conv, sink, NULL);
-    gst_element_sync_state_with_parent(q);
-    gst_element_sync_state_with_parent(conv);
-    gst_element_sync_state_with_parent(sink);
-  }
-
-  if (convert_name == "audioconvert") {
-    gst_element_link_many(q, conv, resample, sink, NULL);
-  }
-  else {
-    gst_element_link_many(q, conv, sink, NULL);
+    resample = gst_element_factory_make ("audioresample", NULL);
+	g_assert_nonnull (resample);
+    gst_bin_add_many (GST_BIN (pipe), q, conv, resample, sink, NULL);
+    gst_element_sync_state_with_parent (q);
+    gst_element_sync_state_with_parent (conv);
+    gst_element_sync_state_with_parent (resample);
+    gst_element_sync_state_with_parent (sink);
+    gst_element_link_many (q, conv, resample, sink, NULL);
+  } else {
+    gst_bin_add_many (GST_BIN (pipe), q, conv, sink, NULL);
+    gst_element_sync_state_with_parent (q);
+    gst_element_sync_state_with_parent (conv);
+    gst_element_sync_state_with_parent (sink);
+	gst_element_link_many (q, conv, sink, NULL);
   }
 
-  qpad = gst_element_get_static_pad(q, "sink");
+  qpad = gst_element_get_static_pad (q, "sink");
 
-  ret = gst_pad_link(pad, qpad);
+  ret = gst_pad_link (pad, qpad);
   g_assert_cmphex (ret, ==, GST_PAD_LINK_OK);
 }
 

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -117,7 +117,7 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
 
   if (convert_name == "audioconvert") {
     resample = gst_element_factory_make ("audioresample", NULL);
-	g_assert_nonnull (resample);
+    g_assert_nonnull (resample);
     gst_bin_add_many (GST_BIN (pipe), q, conv, resample, sink, NULL);
     gst_element_sync_state_with_parent (q);
     gst_element_sync_state_with_parent (conv);
@@ -129,7 +129,7 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
     gst_element_sync_state_with_parent (q);
     gst_element_sync_state_with_parent (conv);
     gst_element_sync_state_with_parent (sink);
-	gst_element_link_many (q, conv, sink, NULL);
+    gst_element_link_many (q, conv, sink, NULL);
   }
 
   qpad = gst_element_get_static_pad (q, "sink");

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -102,28 +102,44 @@ static void
 handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
     const char * sink_name)
 {
-  GstPad *qpad;
-  GstElement *q, *conv, *sink;
-  GstPadLinkReturn ret;
+	GstPad *qpad;
+	GstElement *q, *conv, *resample = NULL, *sink;
+	GstPadLinkReturn ret;
 
-  g_print ("Trying to handle stream with %s ! %s", convert_name, sink_name);
+	q = gst_element_factory_make("queue", NULL);
+	g_assert(q);
+	conv = gst_element_factory_make(convert_name, NULL);
+	g_assert(conv);
+	sink = gst_element_factory_make(sink_name, NULL);
+	g_assert(sink);
 
-  q = gst_element_factory_make ("queue", NULL);
-  g_assert_nonnull (q);
-  conv = gst_element_factory_make (convert_name, NULL);
-  g_assert_nonnull (conv);
-  sink = gst_element_factory_make (sink_name, NULL);
-  g_assert_nonnull (sink);
-  gst_bin_add_many (GST_BIN (pipe), q, conv, sink, NULL);
-  gst_element_sync_state_with_parent (q);
-  gst_element_sync_state_with_parent (conv);
-  gst_element_sync_state_with_parent (sink);
-  gst_element_link_many (q, conv, sink, NULL);
+	if (convert_name == "audioconvert") {
+		resample = gst_element_factory_make("audioresample", NULL);
+		g_assert(resample);
+		gst_bin_add_many(GST_BIN(pipe), q, conv, resample, sink, NULL);
+		gst_element_sync_state_with_parent(q);
+		gst_element_sync_state_with_parent(conv);
+		gst_element_sync_state_with_parent(resample);
+		gst_element_sync_state_with_parent(sink);
+	}
+	else {
+		gst_bin_add_many(GST_BIN(pipe), q, conv, sink, NULL);
+		gst_element_sync_state_with_parent(q);
+		gst_element_sync_state_with_parent(conv);
+		gst_element_sync_state_with_parent(sink);
+	}
 
-  qpad = gst_element_get_static_pad (q, "sink");
+	if (convert_name == "audioconvert") {
+		gst_element_link_many(q, conv, resample, sink, NULL);
+	}
+	else {
+		gst_element_link_many(q, conv, sink, NULL);
+	}
 
-  ret = gst_pad_link (pad, qpad);
-  g_assert_cmphex (ret, ==, GST_PAD_LINK_OK);
+	qpad = gst_element_get_static_pad(q, "sink");
+
+	ret = gst_pad_link(pad, qpad);
+	g_assert_cmphex (ret, ==, GST_PAD_LINK_OK);
 }
 
 static void

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -105,7 +105,7 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
   GstPad *qpad;
   GstElement *q, *conv, *resample, *sink;
   GstPadLinkReturn ret;
-  
+
   g_print ("Trying to handle stream with %s ! %s", convert_name, sink_name);
 
   q = gst_element_factory_make ("queue", NULL);

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -102,44 +102,44 @@ static void
 handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
     const char * sink_name)
 {
-	GstPad *qpad;
-	GstElement *q, *conv, *resample = NULL, *sink;
-	GstPadLinkReturn ret;
+  GstPad *qpad;
+  GstElement *q, *conv, *resample = NULL, *sink;
+  GstPadLinkReturn ret;
 
-	q = gst_element_factory_make("queue", NULL);
-	g_assert(q);
-	conv = gst_element_factory_make(convert_name, NULL);
-	g_assert(conv);
-	sink = gst_element_factory_make(sink_name, NULL);
-	g_assert(sink);
+  q = gst_element_factory_make("queue", NULL);
+  g_assert(q);
+  conv = gst_element_factory_make(convert_name, NULL);
+  g_assert(conv);
+  sink = gst_element_factory_make(sink_name, NULL);
+  g_assert(sink);
 
-	if (convert_name == "audioconvert") {
-		resample = gst_element_factory_make("audioresample", NULL);
-		g_assert(resample);
-		gst_bin_add_many(GST_BIN(pipe), q, conv, resample, sink, NULL);
-		gst_element_sync_state_with_parent(q);
-		gst_element_sync_state_with_parent(conv);
-		gst_element_sync_state_with_parent(resample);
-		gst_element_sync_state_with_parent(sink);
-	}
-	else {
-		gst_bin_add_many(GST_BIN(pipe), q, conv, sink, NULL);
-		gst_element_sync_state_with_parent(q);
-		gst_element_sync_state_with_parent(conv);
-		gst_element_sync_state_with_parent(sink);
-	}
+  if (convert_name == "audioconvert") {
+    resample = gst_element_factory_make("audioresample", NULL);
+    g_assert(resample);
+    gst_bin_add_many(GST_BIN(pipe), q, conv, resample, sink, NULL);
+    gst_element_sync_state_with_parent(q);
+	gst_element_sync_state_with_parent(conv);
+	gst_element_sync_state_with_parent(resample);
+	gst_element_sync_state_with_parent(sink);
+  }
+  else {
+    gst_bin_add_many(GST_BIN(pipe), q, conv, sink, NULL);
+    gst_element_sync_state_with_parent(q);
+    gst_element_sync_state_with_parent(conv);
+    gst_element_sync_state_with_parent(sink);
+  }
 
-	if (convert_name == "audioconvert") {
-		gst_element_link_many(q, conv, resample, sink, NULL);
-	}
-	else {
-		gst_element_link_many(q, conv, sink, NULL);
-	}
+  if (convert_name == "audioconvert") {
+    gst_element_link_many(q, conv, resample, sink, NULL);
+  }
+  else {
+    gst_element_link_many(q, conv, sink, NULL);
+  }
 
-	qpad = gst_element_get_static_pad(q, "sink");
+  qpad = gst_element_get_static_pad(q, "sink");
 
-	ret = gst_pad_link(pad, qpad);
-	g_assert_cmphex (ret, ==, GST_PAD_LINK_OK);
+  ret = gst_pad_link(pad, qpad);
+  g_assert_cmphex (ret, ==, GST_PAD_LINK_OK);
 }
 
 static void

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -115,7 +115,7 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
   sink = gst_element_factory_make (sink_name, NULL);
   g_assert_nonnull (sink);
 
-  if (convert_name == "audioconvert") {
+  if (g_strcmp0 (convert_name, "audioconvert") == 0) {
     resample = gst_element_factory_make ("audioresample", NULL);
     g_assert_nonnull (resample);
     gst_bin_add_many (GST_BIN (pipe), q, conv, resample, sink, NULL);

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -105,6 +105,8 @@ handle_media_stream (GstPad * pad, GstElement * pipe, const char * convert_name,
   GstPad *qpad;
   GstElement *q, *conv, *resample = NULL, *sink;
   GstPadLinkReturn ret;
+  
+  g_print ("Trying to handle stream with %s ! %s", convert_name, sink_name);
 
   q = gst_element_factory_make("queue", NULL);
   g_assert(q);


### PR DESCRIPTION
When adding an audioresample, when the src is audio, fixes both the video and audio linking.
This  was probably the reason why only one frame was shown and then the linking error occured.

Fix could probably be cleaner...
Tested on Windows 10 with GStreamer 1.13.91
don't know if this breaks Linux