### PR TITLE
mp-webrtc-sendrecv.c: add missing comma in the list of package required

### DIFF
--- a/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
+++ b/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
@@ -898,7 +898,7 @@ check_plugins (void)
   gboolean ret;
   GstPlugin *plugin;
   GstRegistry *registry;
-  const gchar *needed[] = { "opus", "nice", "webrtc", "dtls", "srtp"
+  const gchar *needed[] = { "opus", "nice", "webrtc", "dtls", "srtp",
       "rtpmanager", "audiotestsrc", NULL};
 
   registry = gst_registry_get ();


### PR DESCRIPTION
A comma is missing in the list of package required. Thus the package
'srtprtpmanager' is checked instead of packages srtp and rtpmanager.