### PR TITLE
Fix bug in Rust sendrecv demo

### DIFF
--- a/sendrecv/gst-rust/src/main.rs
+++ b/sendrecv/gst-rust/src/main.rs
@@ -126,7 +126,7 @@ fn check_plugins() -> Result<(), Error> {
     let registry = gst::Registry::get();
     let missing = needed
         .iter()
-        .filter(|n| registry.find_plugin(n).is_some())
+        .filter(|n| registry.find_plugin(n).is_none())
         .map(|n| *n)
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
The Rust sendrecv demo had a bug in the check_plugins() function after the cleanup, where it confused missin with non missing plugins.