### PR TITLE
on_server_message: Do not unref message GBytes

### DIFF
--- a/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
+++ b/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
@@ -755,20 +755,19 @@ static void
 on_server_message (SoupWebsocketConnection * conn, SoupWebsocketDataType type,
     GBytes * message, gpointer user_data)
 {
-  gsize size;
-  gchar *text, *data;
+  gchar *text;
 
   switch (type) {
     case SOUP_WEBSOCKET_DATA_BINARY:
       g_printerr ("Received unknown binary message, ignoring\n");
-      g_bytes_unref (message);
       return;
-    case SOUP_WEBSOCKET_DATA_TEXT:
-      data = g_bytes_unref_to_data (message, &size);
+    case SOUP_WEBSOCKET_DATA_TEXT: {
+      gsize size;
+      const gchar *data = g_bytes_get_data (message, &size);
       /* Convert to NULL-terminated string */
       text = g_strndup (data, size);
-      g_free (data);
       break;
+    }
     default:
       g_assert_not_reached ();
   }

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -383,20 +383,19 @@ static void
 on_server_message (SoupWebsocketConnection * conn, SoupWebsocketDataType type,
     GBytes * message, gpointer user_data)
 {
-  gsize size;
-  gchar *text, *data;
+  gchar *text;
 
   switch (type) {
     case SOUP_WEBSOCKET_DATA_BINARY:
       g_printerr ("Received unknown binary message, ignoring\n");
-      g_bytes_unref (message);
       return;
-    case SOUP_WEBSOCKET_DATA_TEXT:
-      data = g_bytes_unref_to_data (message, &size);
+    case SOUP_WEBSOCKET_DATA_TEXT: {
+      gsize size;
+      const gchar *data = g_bytes_get_data (message, &size);
       /* Convert to NULL-terminated string */
       text = g_strndup (data, size);
-      g_free (data);
       break;
+    }
     default:
       g_assert_not_reached ();
   }


### PR DESCRIPTION
We don't own the reference. Since GLib 2.58, the `g_bytes_unref` that
follows the signal emission in libsoup loudly complains about the
attempt to underflow the refcount.