### PR TITLE
Replace deprecated onaddstream with ontrack; fixes #98

### DIFF
--- a/sendrecv/js/index.html
+++ b/sendrecv/js/index.html
@@ -22,7 +22,7 @@
   </head>
 
   <body>
-    <div><video id="stream" autoplay>Your browser doesn't support video</video></div>
+    <div><video id="stream" autoplay playsinline>Your browser doesn't support video</video></div>
     <div>Status: <span id="status">unknown</span></div>
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>

--- a/sendrecv/js/webrtc.js
+++ b/sendrecv/js/webrtc.js
@@ -219,15 +219,10 @@ function websocketServerConnect() {
     ws_conn.addEventListener('close', onServerClose);
 }
 
-function onRemoteStreamAdded(event) {
-    videoTracks = event.stream.getVideoTracks();
-    audioTracks = event.stream.getAudioTracks();
-
-    if (videoTracks.length > 0) {
-        console.log('Incoming stream: ' + videoTracks.length + ' video tracks and ' + audioTracks.length + ' audio tracks');
-        getVideoElement().srcObject = event.stream;
-    } else {
-        handleIncomingError('Stream with unknown tracks added, resetting');
+function onRemoteTrack(event) {
+    if (getVideoElement().srcObject !== event.streams[0]) {
+        console.log('Incoming stream');
+        getVideoElement().srcObject = event.streams[0];
     }
 }
 
@@ -283,7 +278,7 @@ function createCall(msg) {
     send_channel.onerror = handleDataChannelError;
     send_channel.onclose = handleDataChannelClose;
     peer_connection.ondatachannel = onDataChannel;
-    peer_connection.onaddstream = onRemoteStreamAdded;
+    peer_connection.ontrack = onRemoteTrack;
     /* Send our video/audio to the other peer */
     local_stream_promise = getLocalStream().then((stream) => {
         console.log('Adding local stream');


### PR DESCRIPTION
This is a quick fix for #98 using the sample code from [RTCPeerConnection demos](https://webrtc.github.io/samples/src/content/peerconnection/pc1/)

Tested on the following browsers:

MacOS 10.14.4:
- Safari 12.1 => OK
- Chrome 73.0.3683.103 => OK
- Firefox 66.0.3 => OK
- Opera 60.0.3255.27 => FAIL (no video or sound)

Safari on iOS 12.2:
- iPad Air => OK
- iPhone SE => FAIL (frozen video, no sound)

