### PR TITLE
use gst_pad_link in pad-added callbacks

### DIFF
--- a/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
+++ b/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
@@ -184,6 +184,7 @@ on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
 
   sinkpad = gst_element_get_static_pad (decodebin, "sink");
   gst_pad_link (pad, sinkpad);
+  gst_object_unref (sinkpad);
 }
 
 static void

--- a/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
+++ b/multiparty-sendrecv/gst/mp-webrtc-sendrecv.c
@@ -171,6 +171,7 @@ static void
 on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
 {
   GstElement *decodebin;
+  GstPad *sinkpad;
 
   if (GST_PAD_DIRECTION (pad) != GST_PAD_SRC)
     return;
@@ -180,7 +181,9 @@ on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
       G_CALLBACK (on_incoming_decodebin_stream), pipe);
   gst_bin_add (GST_BIN (pipe), decodebin);
   gst_element_sync_state_with_parent (decodebin);
-  gst_element_link (webrtc, decodebin);
+
+  sinkpad = gst_element_get_static_pad (decodebin, "sink");
+  gst_pad_link (pad, sinkpad);
 }
 
 static void

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -172,6 +172,7 @@ static void
 on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
 {
   GstElement *decodebin;
+  GstPad *sinkpad;
 
   if (GST_PAD_DIRECTION (pad) != GST_PAD_SRC)
     return;
@@ -181,7 +182,9 @@ on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
       G_CALLBACK (on_incoming_decodebin_stream), pipe);
   gst_bin_add (GST_BIN (pipe), decodebin);
   gst_element_sync_state_with_parent (decodebin);
-  gst_element_link (webrtc, decodebin);
+
+  sinkpad = gst_element_get_static_pad (decodebin, "sink");
+  gst_pad_link (pad, sinkpad);
 }
 
 static void

--- a/sendrecv/gst/webrtc-sendrecv.c
+++ b/sendrecv/gst/webrtc-sendrecv.c
@@ -185,6 +185,7 @@ on_incoming_stream (GstElement * webrtc, GstPad * pad, GstElement * pipe)
 
   sinkpad = gst_element_get_static_pad (decodebin, "sink");
   gst_pad_link (pad, sinkpad);
+  gst_object_unref (sinkpad);
 }
 
 static void


### PR DESCRIPTION
do no use gst_element_link but gst_pad_link in pad-added callbacks to  prevent situations where on multiple incoming streams they might not get linked correctly and leave a stream unconnected

solves issue #100 