### PR TITLE
Added a basic health check endpoint to the server

### DIFF
--- a/signalling/simple-server.py
+++ b/signalling/simple-server.py
@@ -14,6 +14,7 @@ import logging
 import asyncio
 import websockets
 import argparse
+import http
 
 from concurrent.futures._base import TimeoutError
 
@@ -45,6 +46,10 @@ sessions = dict()
 rooms = dict()
 
 ############### Helper functions ###############
+
+async def health_check(path, request_headers):
+    if path == "/health/":
+        return http.HTTPStatus.OK, [], b"OK\n"
 
 async def recv_msg_ping(ws, raddr):
     '''
@@ -265,7 +270,7 @@ if not options.disable_ssl:
 
 print("Listening on https://{}:{}".format(*ADDR_PORT))
 # Websocket server
-wsd = websockets.serve(handler, *ADDR_PORT, ssl=sslctx,
+wsd = websockets.serve(handler, *ADDR_PORT, ssl=sslctx, process_request=health_check,
                        # Maximum number of messages that websockets will pop
                        # off the asyncio and OS buffers per connection. See:
                        # https://websockets.readthedocs.io/en/stable/api.html#websockets.protocol.WebSocketCommonProtocol

--- a/signalling/simple-server.py
+++ b/signalling/simple-server.py
@@ -25,6 +25,7 @@ parser.add_argument('--port', default=8443, type=int, help='Port to listen on')
 parser.add_argument('--keepalive-timeout', dest='keepalive_timeout', default=30, type=int, help='Timeout for keepalive (in seconds)')
 parser.add_argument('--cert-path', default=os.path.dirname(__file__))
 parser.add_argument('--disable-ssl', default=False, help='Disable ssl', action='store_true')
+parser.add_argument('--health', default='/health', help='Health check route')
 
 options = parser.parse_args(sys.argv[1:])
 
@@ -48,7 +49,7 @@ rooms = dict()
 ############### Helper functions ###############
 
 async def health_check(path, request_headers):
-    if path == "/health/":
+    if path == options.health:
         return http.HTTPStatus.OK, [], b"OK\n"
 
 async def recv_msg_ping(ws, raddr):


### PR DESCRIPTION
Self hosted service requires a health check.  Added a `/health/` HTTP route for basic health checking.  See https://websockets.readthedocs.io/en/stable/deployment.html?highlight=health#port-sharing for reference.