### PR TITLE
Fix error during the build of Docker image

### DIFF
--- a/sendrecv/gst/Dockerfile
+++ b/sendrecv/gst/Dockerfile
@@ -1,8 +1,8 @@
 FROM maxmcd/gstreamer:1.14-buster
 
+RUN apt-get update --allow-releaseinfo-change
+RUN apt-get update --fix-missing
 RUN apt-get install -y libjson-glib-dev
-# RUN apk update
-# RUN apk add json-glib-dev libsoup-dev
 
 WORKDIR /opt/
 COPY . /opt/


### PR DESCRIPTION
I added the rows --allow-releaseinfo-change and --fix-missing in order to fix the following errors:

```
E: Repository 'http://security-cdn.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'testing' to 'stable'
E: Repository 'http://cdn-fastly.deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'testing' to 'stable'
E: Repository 'http://cdn-fastly.deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'testing-updates' to 'stable-updates'
```

Causing the failure of docker image build