### PR TITLE
Fix:TypeError: 'Structure' object is not subscriptable #140

### DIFF
--- a/sendrecv/gst/webrtc-sendrecv.py
+++ b/sendrecv/gst/webrtc-sendrecv.py
@@ -50,7 +50,7 @@ class WebRTCClient:
     def on_offer_created(self, promise, _, __):
         promise.wait()
         reply = promise.get_reply()
-        offer = reply['offer']
+        offer = reply.get_value('offer')
         promise = Gst.Promise.new()
         self.webrtc.emit('set-local-description', offer, promise)
         promise.interrupt()


### PR DESCRIPTION
As for some Get.Structure the reply can not be subscripted, use get_value to fix it.

https://lazka.github.io/pgi-docs/Gst-1.0/classes/Structure.html#Gst.Structure.n_fields