### PR TITLE
Target basic gobject introspection API instead of python-gstreamer

### DIFF
--- a/sendrecv/gst/webrtc-sendrecv.py
+++ b/sendrecv/gst/webrtc-sendrecv.py
@@ -50,7 +50,7 @@ class WebRTCClient:
     def on_offer_created(self, promise, _, __):
         promise.wait()
         reply = promise.get_reply()
-        offer = reply['offer']
+        offer = reply.get_value('offer')
         promise = Gst.Promise.new()
         self.webrtc.emit('set-local-description', offer, promise)
         promise.interrupt()
@@ -71,14 +71,16 @@ class WebRTCClient:
             return
 
         caps = pad.get_current_caps()
-        assert (len(caps))
-        s = caps[0]
+        assert (caps.get_size())
+        s = caps.get_structure(0)
         name = s.get_name()
         if name.startswith('video'):
             q = Gst.ElementFactory.make('queue')
             conv = Gst.ElementFactory.make('videoconvert')
             sink = Gst.ElementFactory.make('autovideosink')
-            self.pipe.add(q, conv, sink)
+            self.pipe.add(q)
+            self.pipe.add(conv)
+            self.pipe.add(sink)
             self.pipe.sync_children_states()
             pad.link(q.get_static_pad('sink'))
             q.link(conv)
@@ -88,7 +90,10 @@ class WebRTCClient:
             conv = Gst.ElementFactory.make('audioconvert')
             resample = Gst.ElementFactory.make('audioresample')
             sink = Gst.ElementFactory.make('autoaudiosink')
-            self.pipe.add(q, conv, resample, sink)
+            self.pipe.add(q)
+            self.pipe.add(conv)
+            self.pipe.add(resample)
+            self.pipe.add(sink)
             self.pipe.sync_children_states()
             pad.link(q.get_static_pad('sink'))
             q.link(conv)


### PR DESCRIPTION
Updated Python syntax of `sendrevc.py` so that it works with gstreamer 1.16 python bindings, as found in Ubuntu 20.04.
I do not know if this is backward compatible, though, as I haven't tested with older versions of gstreamer. 