### PR TITLE
html: charset

### DIFF
--- a/sendrecv/js/index.html
+++ b/sendrecv/js/index.html
@@ -11,6 +11,7 @@
 -->
 <html>
   <head>
+    <meta charset="utf-8"/>
     <style>
       .error { color: red; }
     </style>


### PR DESCRIPTION
Avoid warning:
The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.